### PR TITLE
Stop adding a trailing space to empty `iex>` lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Stop adding a trailing space to empty `iex>` lines.
+
 ## 0.3.1 (2024-11-24)
 
 - Respect `line_length` option when formatting the whole `.ex` file. 

--- a/lib/doctest_formatter/formatter.ex
+++ b/lib/doctest_formatter/formatter.ex
@@ -124,7 +124,7 @@ defmodule DoctestFormatter.Formatter do
     |> Enum.with_index()
     |> Enum.map(fn {line, index} ->
       line_with_prompt =
-        if line === "" do
+        if line == "" do
           String.trim(get_prompt(chunk, index))
         else
           get_prompt(chunk, index) <> line

--- a/lib/doctest_formatter/formatter.ex
+++ b/lib/doctest_formatter/formatter.ex
@@ -123,7 +123,14 @@ defmodule DoctestFormatter.Formatter do
     end
     |> Enum.with_index()
     |> Enum.map(fn {line, index} ->
-      Indentation.indent(get_prompt(chunk, index) <> line, chunk.indentation)
+      line_with_prompt =
+        if line === "" do
+          String.trim(get_prompt(chunk, index))
+        else
+          get_prompt(chunk, index) <> line
+        end
+
+      Indentation.indent(line_with_prompt, chunk.indentation)
     end)
   end
 

--- a/test/doctest_formatter/formatter_test.exs
+++ b/test/doctest_formatter/formatter_test.exs
@@ -806,7 +806,7 @@ defmodule DoctestFormatter.FormatterTest do
           or
 
             iex> 3
-            ...>    Foo.add( 7 )
+            ...>    |> Foo.add( 7 )
                 10
           \"""
           @spec add(a :: integer, b :: integer) :: integer
@@ -826,7 +826,7 @@ defmodule DoctestFormatter.FormatterTest do
           or
 
             iex> 3
-            ...> Foo.add(7)
+            ...> |> Foo.add(7)
             10
           \"""
           @spec add(a :: integer, b :: integer) :: integer
@@ -1082,6 +1082,47 @@ defmodule DoctestFormatter.FormatterTest do
         """
 
       output = format(input, opts)
+      assert output == desired_output
+    end
+
+    test "does not create trailing spaces" do
+      input =
+        """
+        defmodule Foo do
+          @doc \"""
+          iex>   x = 3#{" "}
+          iex> #{"   "}
+          iex>    y = 4#{"   "}
+          iex>#{}
+          iex>    Foo.add(x,y)#{"   "}
+          7
+          \"""
+          @spec add(a :: integer, b :: integer) :: integer
+          def add(a, b) do
+            a + b
+          end
+        end
+        """
+
+      desired_output =
+        """
+        defmodule Foo do
+          @doc \"""
+          iex> x = 3
+          ...>
+          ...> y = 4
+          ...>
+          ...> Foo.add(x, y)
+          7
+          \"""
+          @spec add(a :: integer, b :: integer) :: integer
+          def add(a, b) do
+            a + b
+          end
+        end
+        """
+
+      output = format(input, [])
       assert output == desired_output
     end
   end


### PR DESCRIPTION
Resolves https://github.com/angelikatyborska/doctest_formatter/issues/39