### PR TITLE
Fix Elixir 1.19.0-rc.0 compatibility

### DIFF
--- a/lib/doctest_formatter/formatter.ex
+++ b/lib/doctest_formatter/formatter.ex
@@ -79,8 +79,8 @@ defmodule DoctestFormatter.Formatter do
     forms
     |> Code.quoted_to_algebra(to_algebra_opts)
     |> Inspect.Algebra.format(desired_line_length)
-    |> Kernel.++(["\n"])
     |> IO.iodata_to_binary()
+    |> Kernel.<>("\n")
   end
 
   defp format_doc_content(doc_content, opts, doc_metadata) do


### PR DESCRIPTION
The ++ operator was being used incorrectly to append a newline. Changed to use <> operator after converting iodata to binary.

Fixes ArgumentError when formatting files with Elixir 1.19.0-rc.0

Fixes #47 